### PR TITLE
Check markdown for url formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 🌐️ [English Report](/reports/250527_llm_landscape/250527_llm_report_en.md) | [中文报告](/reports/250527_llm_landscape/250527_llm_report_cn.md)
 
-![https://antoss-landscape.my.canva.site](/reports/250913_llm_landscape/figures/llm_development_landscape.png)
+![LLM Development Landscape](/reports/250913_llm_landscape/figures/llm_development_landscape.png)
 
-![https://antoss-landscape.my.canva.site](/reports/250913_llm_landscape/figures/large_models_landscape.png)
+![Large Models Landscape](/reports/250913_llm_landscape/figures/large_models_landscape.png)
 
 
 

--- a/reports/250527_llm_landscape/250527_llm_report_cn.md
+++ b/reports/250527_llm_landscape/250527_llm_report_cn.md
@@ -32,7 +32,9 @@
 
 最终，呈现下面这张 **<font style="color:rgb(28, 30, 33);">2025 年大模型开源开发生态全景图，</font>**<font style="color:rgb(28, 30, 33);">截止 2025 年 5 月发布时，全景图上收录了 </font>**<font style="color:rgba(253,58,184,1);">135 </font>**<font style="color:rgb(28, 30, 33);">个项目，涵盖了</font>智能体应用层和模型基础设施层一共 **<font style="color:rgba(253,58,184,1);">19</font>** 个技术领域。虽然我们非常努力想从中挖掘更多信息，但我们也完全明白，社区的数据既不全面也不完全准确，而且也不一定能反映出很多最新最优秀的技术变化，我们只希望这个报告能给大家一些有益的参考，有什么错漏之处和其他值得补充的观点，也欢迎大家反馈给我们。
 
-![地址： https://antoss-landscape.my.canva.site](/figures/2.png)
+![2025年大模型开源开发生态全景图](/figures/2.png)
+
+查看全景图请访问：[https://antoss-landscape.my.canva.site](https://antoss-landscape.my.canva.site)
 
 
 

--- a/reports/250527_llm_landscape/250527_llm_report_en.md
+++ b/reports/250527_llm_landscape/250527_llm_report_en.md
@@ -5,7 +5,9 @@
 ![](./figures/1.png)
 
 ## The LLM Development Ecosystem: A Snapshot
-![https://antoss-landscape.my.canva.site](/figures/2.png)
+![LLM Development Ecosystem Landscape 2025](/figures/2.png)
+
+View the landscape online: [https://antoss-landscape.my.canva.site](https://antoss-landscape.my.canva.site)
 
 
 


### PR DESCRIPTION
Corrected Markdown image alt text and added explicit links for `https://antoss-landscape.my.canva.site`.

The URL was incorrectly used as alt text for images, which is not standard practice and affects accessibility. This PR replaces the alt text with descriptive content and adds explicit links where the URL needs to be displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-9610f7cd-8907-4d88-823f-8838c3647375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9610f7cd-8907-4d88-823f-8838c3647375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

